### PR TITLE
Updated keystorm.yml

### DIFF
--- a/config/keystorm.yml
+++ b/config/keystorm.yml
@@ -11,25 +11,23 @@ defaults: &defaults
   oidc:
     matcher: <%= ENV['KEYSTORM_OIDC_MATCHER'] || 'urn:mace:egi.eu:aai.egi.eu:{role}@{group}' %>
   voms:
-    default_email: <%= ENV['KEYSTORM_VOMS_DEFAULT_EMAIL'] || 'nomail@nomail.com' %>
+    default_email: <%= ENV['KEYSTORM_VOMS_DEFAULT_EMAIL'] || 'root@localhost' %>
   catalog: # List of catalog entries
     - endpoints:
-        - region_id: rOCCILand
-          url: http://rocciland.org/v1/service
-          region: rOCCILand
+        - region_id: rOCCI-server
+          url: <%= ENV['KEYSTORM_CATALOG_ENDPOINTS_URL'] || 'https://localhost:11443/' %>
+          region: rOCCI-server
           interface: public
           id: 8d243dbd892234d1bccfbfb29f2ad947b2ae4cd2
       type: compute
       id: 82615421269f13b16e8744d2d84509b0c0c76de5
-      name: rOCCI
+      name: rOCCI-server
 
 production:
   <<: *defaults
-  log_level: info
 
 development:
   <<: *defaults
-  log_level: debug
 
 test:
   <<: *defaults

--- a/spec/models/auth/voms_spec.rb
+++ b/spec/models/auth/voms_spec.rb
@@ -65,7 +65,7 @@ describe Auth::Voms, type: :model do
 
       let(:correct_hash) do
         { id: '6694ddfebb77800c4d0aa0c6e3a7eb35bf7b3df83c312c23b8ca470930c4317b',
-          email: 'nomail@nomail.com',
+          email: 'root@localhost',
           groups: [],
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
@@ -95,7 +95,7 @@ describe Auth::Voms, type: :model do
 
       let(:correct_hash) do
         { id: '6694ddfebb77800c4d0aa0c6e3a7eb35bf7b3df83c312c23b8ca470930c4317b',
-          email: 'nomail@nomail.com',
+          email: 'root@localhost',
           groups: [{ id: 'fedcloud.egi.eu', roles: ['actor'] }],
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',


### PR DESCRIPTION
* Making catalog endpoint url configurable via `KEYSTORM_CATALOG_ENDPOINTS_URL`
* Removed `log_level` overrides in different ENVs