### PR TITLE
NULL roles will now create group with no roles

### DIFF
--- a/app/models/auth/voms.rb
+++ b/app/models/auth/voms.rb
@@ -42,9 +42,9 @@ module Auth
         groups = Hash.new { |h, k| h[k] = [] }
         hash['GRST_VOMS_FQANS'].split(';').each do |line|
           group = parse_group!(line)
-          groups.merge!(group) { |_, oldval, newval| (oldval + newval).uniq } if group
+          groups.merge!(group) { |_, oldval, newval| oldval + newval } if group
         end
-        groups.map { |key, value| { id: key, roles: value } }
+        groups.map { |key, value| { id: key, roles: value.uniq } }
       end
 
       def parse_group!(line)

--- a/app/models/auth/voms.rb
+++ b/app/models/auth/voms.rb
@@ -49,7 +49,7 @@ module Auth
 
       def parse_group(line)
         matches = line.match(VOMS_GROUP_REGEXP)
-        return unless matches
+        raise Errors::AuthenticationError, 'voms group env variable has invalid format' unless matches
         if matches[:role] == 'NULL'
           { matches[:group] => [] }
         else

--- a/app/models/auth/voms.rb
+++ b/app/models/auth/voms.rb
@@ -41,10 +41,20 @@ module Auth
         raise Errors::AuthenticationError, 'voms group env variable is not set' unless hash.key?('GRST_VOMS_FQANS')
         groups = Hash.new { |h, k| h[k] = [] }
         hash['GRST_VOMS_FQANS'].split(';').each do |line|
-          matches = line.match(VOMS_GROUP_REGEXP)
-          groups[matches[:group]] << matches[:role] if matches && matches[:role] != 'NULL'
+          group = parse_group(line)
+          groups.merge!(group) { |_, oldval, newval| oldval + newval } if group
         end
         groups.map { |key, value| { id: key, roles: value } }
+      end
+
+      def parse_group(line)
+        matches = line.match(VOMS_GROUP_REGEXP)
+        return unless matches
+        if matches[:role] == 'NULL'
+          { matches[:group] => [] }
+        else
+          { matches[:group] => [matches[:role]] }
+        end
       end
     end
   end

--- a/app/models/auth/voms.rb
+++ b/app/models/auth/voms.rb
@@ -41,15 +41,16 @@ module Auth
         raise Errors::AuthenticationError, 'voms group env variable is not set' unless hash.key?('GRST_VOMS_FQANS')
         groups = Hash.new { |h, k| h[k] = [] }
         hash['GRST_VOMS_FQANS'].split(';').each do |line|
-          group = parse_group(line)
-          groups.merge!(group) { |_, oldval, newval| oldval + newval } if group
+          group = parse_group!(line)
+          groups.merge!(group) { |_, oldval, newval| (oldval + newval).uniq } if group
         end
         groups.map { |key, value| { id: key, roles: value } }
       end
 
-      def parse_group(line)
+      def parse_group!(line)
         matches = line.match(VOMS_GROUP_REGEXP)
         raise Errors::AuthenticationError, 'voms group env variable has invalid format' unless matches
+        return if matches[:group].include?('/')
         if matches[:role] == 'NULL'
           { matches[:group] => [] }
         else

--- a/app/models/auth/voms.rb
+++ b/app/models/auth/voms.rb
@@ -5,7 +5,7 @@ module Auth
     HEADERS_FILTERS = Rails.configuration.keystorm['behind_proxy'] ? %w[HTTP_SSL HTTP_GRST].freeze : %w[SSL GRST].freeze
 
     class << self
-      VOMS_GROUP_REGEXP = %r{^\/(?<group>[^\s]+)\/Role=(?<role>[^\s]+)\/Capability=NULL$}
+      VOMS_GROUP_REGEXP = %r{^\/(?<group>[^\s]+)\/Role=(?<role>[^\s]+)\/Capability=(?<capability>[^\s]+)$}
 
       def unified_credentials(hash)
         Rails.logger.debug { "Building VOMS unified credentials from #{hash.inspect}" }

--- a/app/models/auth/voms.rb
+++ b/app/models/auth/voms.rb
@@ -50,12 +50,11 @@ module Auth
       def parse_group!(line)
         matches = line.match(VOMS_GROUP_REGEXP)
         raise Errors::AuthenticationError, 'voms group env variable has invalid format' unless matches
-        return if matches[:group].include?('/')
-        if matches[:role] == 'NULL'
-          { matches[:group] => [] }
-        else
-          { matches[:group] => [matches[:role]] }
+        if matches[:group].include?('/')
+          Rails.logger.warn { "Ignoring matched VOMS subgroup: #{matches[:group]}" }
+          return
         end
+        matches[:role] == 'NULL' ? { matches[:group] => [] } : { matches[:group] => [matches[:role]] }
       end
     end
   end

--- a/spec/models/auth/voms_spec.rb
+++ b/spec/models/auth/voms_spec.rb
@@ -29,6 +29,24 @@ describe Auth::Voms, type: :model do
   end
 
   describe '#parse_hash_groups!' do
+    context 'with valid groups with different capabilities' do
+      let(:env_hash) do
+        { 'GRST_VOMS_FQANS' => '/coolclub/Role=NULL/Capability=NULL;' \
+                               '/nicepeople/Role=model/Capability=full;' \
+                               '/others/Role=outofideas/Capability=none' }
+      end
+
+      let(:final_groups) do
+        [{ id: 'coolclub', roles: %w[] },
+         { id: 'nicepeople', roles: %w[model] },
+         { id: 'others', roles: %w[outofideas] }]
+      end
+
+      it 'will drop out subgroups' do
+        expect(Auth::Voms.send(:parse_hash_groups!, env_hash)).to eq(final_groups)
+      end
+    end
+
     context 'with group with subgroups' do
       let(:env_hash) do
         { 'GRST_VOMS_FQANS' => '/coolclub/Role=NULL/Capability=NULL;' \

--- a/spec/models/auth/voms_spec.rb
+++ b/spec/models/auth/voms_spec.rb
@@ -29,6 +29,22 @@ describe Auth::Voms, type: :model do
   end
 
   describe '#parse_hash_groups!' do
+    context 'with invalid groups' do
+      let(:env_hash) do
+        { 'GRST_VOMS_FQANS' => '/coolclub/Role=NULL/Capability=NUL;' \
+                               '/nerds/Roe=LL/Capabili=NLL;' \
+                               '/coolclRole=boyz/Capability=NULL;' \
+                               '/programmers/Role=useless/Capability=NULL;' \
+                               '/programmers/Role=useful/Cability=NULL;' \
+                               '/testes/Role=useCapability=NLL' }
+      end
+
+      it 'will raise error' do
+        expect { Auth::Voms.send(:parse_hash_groups!, env_hash) }.to \
+          raise_error(Errors::AuthenticationError)
+      end
+    end
+
     context 'with all kinds of groups' do
       let(:env_hash) do
         { 'GRST_VOMS_FQANS' => '/coolclub/Role=NULL/Capability=NULL;' \

--- a/spec/models/auth/voms_spec.rb
+++ b/spec/models/auth/voms_spec.rb
@@ -28,6 +28,30 @@ describe Auth::Voms, type: :model do
     end
   end
 
+  describe '#parse_hash_groups!' do
+    context 'with all kinds of groups' do
+      let(:env_hash) do
+        { 'GRST_VOMS_FQANS' => '/coolclub/Role=NULL/Capability=NULL;' \
+                               '/nerds/Role=NULL/Capability=NULL;' \
+                               '/coolclub/Role=boyz/Capability=NULL;' \
+                               '/programmers/Role=useless/Capability=NULL;' \
+                               '/programmers/Role=useful/Capability=NULL;' \
+                               '/testers/Role=useless/Capability=NULL' }
+      end
+
+      let(:final_groups) do
+        [{ id: 'coolclub', roles: %w[boyz] },
+         { id: 'nerds', roles: %w[] },
+         { id: 'programmers', roles: %w[useless useful] },
+         { id: 'testers', roles: %w[useless] }]
+      end
+
+      it 'will parse groups correctly' do
+        expect(Auth::Voms.send(:parse_hash_groups!, env_hash)).to eq(final_groups)
+      end
+    end
+  end
+
   describe '#parse_hash_exp!' do
     context 'with correct hash' do
       let(:exp_hash) do
@@ -66,7 +90,7 @@ describe Auth::Voms, type: :model do
       let(:correct_hash) do
         { id: '6694ddfebb77800c4d0aa0c6e3a7eb35bf7b3df83c312c23b8ca470930c4317b',
           email: 'root@localhost',
-          groups: [],
+          groups: [{ id: 'fedcloud.egi.eu', roles: [] }],
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
           identity: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',

--- a/spec/models/auth/voms_spec.rb
+++ b/spec/models/auth/voms_spec.rb
@@ -29,6 +29,36 @@ describe Auth::Voms, type: :model do
   end
 
   describe '#parse_hash_groups!' do
+    context 'with group with subgroups' do
+      let(:env_hash) do
+        { 'GRST_VOMS_FQANS' => '/coolclub/Role=NULL/Capability=NULL;' \
+                               '/testers/oldpeople/Role=useless/Capability=NULL' }
+      end
+
+      let(:final_groups) do
+        [{ id: 'coolclub', roles: %w[] }]
+      end
+
+      it 'will drop out subgroups' do
+        expect(Auth::Voms.send(:parse_hash_groups!, env_hash)).to eq(final_groups)
+      end
+    end
+
+    context 'with multiple same groups with same roles' do
+      let(:env_hash) do
+        { 'GRST_VOMS_FQANS' => '/coolclub/Role=gamers/Capability=NULL;' \
+                               '/coolclub/Role=gamers/Capability=NULL' }
+      end
+
+      let(:final_groups) do
+        [{ id: 'coolclub', roles: %w[gamers] }]
+      end
+
+      it 'wont have duplicate roles' do
+        expect(Auth::Voms.send(:parse_hash_groups!, env_hash)).to eq(final_groups)
+      end
+    end
+
     context 'with invalid groups' do
       let(:env_hash) do
         { 'GRST_VOMS_FQANS' => '/coolclub/Role=NULL/Capability=NUL;' \


### PR DESCRIPTION
Also add spec for group parsing.

For reviewers:
I had to split parse_hash_group! into multiple methods (thanks to rubocop), so I added parse group method that parses one line of FQANS into hash { <groupname> => [<rolename>] } or without <rolename> if rolename was NULL. Then the return value of this method is merged with groups hash that will be eventually return value of parse_hash_group! method. I hope this will help you at least a bit with understanding this pull request.

PS: What should happen if parse_hash_group! receives incorrect groups format? For example:  'coolclRole=boyz/Capability=NULL;'? Should the whole group parsing fail with appropriate error message , or should this one line be ignored?