### PR TITLE
Add expiration window option

### DIFF
--- a/app/models/auth/expirable.rb
+++ b/app/models/auth/expirable.rb
@@ -1,7 +1,11 @@
 module Auth
   module Expirable
     def expiration
-      (Time.now.to_i + Rails.configuration.keystorm['expiration_window']).to_s
+      Time.now.to_i + expiration_window
+    end
+
+    def expiration_window
+      Rails.configuration.keystorm['expiration_window'].to_i
     end
   end
 end

--- a/app/models/auth/expirable.rb
+++ b/app/models/auth/expirable.rb
@@ -1,0 +1,7 @@
+module Auth
+  module Expirable
+    def expiration
+      (Time.now.to_i + Rails.configuration.keystorm['expiration_window']).to_s
+    end
+  end
+end

--- a/app/models/auth/oidc.rb
+++ b/app/models/auth/oidc.rb
@@ -1,5 +1,7 @@
 module Auth
   class Oidc
+    extend Expirable
+
     HEADERS_FILTERS = Rails.configuration.keystorm['behind_proxy'] ? %w[HTTP_OIDC].freeze : %w[OIDC].freeze
 
     class << self
@@ -9,7 +11,6 @@ module Auth
         groups: 'OIDC_edu_person_entitlements',
         name: 'OIDC_name',
         identity: 'OIDC_sub',
-        expiration: 'OIDC_access_token_expires',
         issuer: 'OIDC_iss',
         acr: 'OIDC_acr'
       }.freeze
@@ -20,6 +21,7 @@ module Auth
         uc_hash = ENV_NAMES.map { |key, value| [key, hash[value]] }.to_h
         uc_hash[:authentication] = { type: 'federation', method: 'oidc' }
         uc_hash[:groups] = parse_hash_groups(hash)
+        uc_hash[:expiration] = expiration
         UnifiedCredentials.new(uc_hash)
       end
 

--- a/config/keystorm.yml
+++ b/config/keystorm.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     secret: <%= ENV['KEYSTORM_OPENNEBULA_SECRET'] %>
   log_level: <%= ENV['KEYSTORM_LOG_LEVEL'] || 'info' %>
   audit_file: <%= ENV['KEYSTORM_AUDIT_FILE'] || Rails.root.join('log', 'audit.log') %>
-  expiration_window: <%= ENV['KEYSTORM_EXPIRATION_WINDOW'] || 691_200 %>
+  expiration_window: <%= ENV['KEYSTORM_EXPIRATION_WINDOW'] || 28_800 %>
   behind_proxy: <%= ENV['KEYSTORM_BEHIND_PROXY'] || true %>
   token_cipher: <%= ENV['KEYSTORM_TOKEN_CIPHER'] || 'AES-128-CBC' %>
   token_key: <%= ENV['KEYSTORM_TOKEN_KEY'] %>

--- a/config/keystorm.yml
+++ b/config/keystorm.yml
@@ -6,6 +6,7 @@ defaults: &defaults
     secret: <%= ENV['KEYSTORM_OPENNEBULA_SECRET'] %>
   log_level: <%= ENV['KEYSTORM_LOG_LEVEL'] || 'info' %>
   audit_file: <%= ENV['KEYSTORM_AUDIT_FILE'] || Rails.root.join('log', 'audit.log') %>
+  expiration_window: <%= ENV['KEYSTORM_EXPIRATION_WINDOW'] || 691_200 %>
   behind_proxy: <%= ENV['KEYSTORM_BEHIND_PROXY'] || true %>
   token_cipher: <%= ENV['KEYSTORM_TOKEN_CIPHER'] || 'AES-128-CBC' %>
   token_key: <%= ENV['KEYSTORM_TOKEN_KEY'] %>

--- a/spec/controllers/v3/auth/federation_controller_spec.rb
+++ b/spec/controllers/v3/auth/federation_controller_spec.rb
@@ -74,7 +74,7 @@ describe V3::Auth::FederationController do
         authentication:  { type: 'federation', method: 'oidc' },
         name:            'Ben Dover',
         identity:        '1',
-        expiration:      '1000691200',
+        expiration:      '1000028800',
         issuer:          'gogol.com',
         acr:             'goglo.com'
       }
@@ -88,7 +88,7 @@ describe V3::Auth::FederationController do
           'OIDC_sub'                     => '1',
           'OIDC_email'                   => 'ben.dover@majl.ru',
           'OIDC_edu_person_entitlements' => 'urn:mace:egi.eu:aai.egi.eu:member@fedcloud.egi.eu',
-          'OIDC_access_token_expires'    => '1000691200',
+          'OIDC_access_token_expires'    => '1000028800',
           'OIDC_name'                    => 'Ben Dover',
           'OIDC_iss'                     => 'gogol.com',
           'OIDC_acr'                     => 'goglo.com'
@@ -136,7 +136,7 @@ describe V3::Auth::FederationController do
           'HTTP_OIDC_sub'                     => '1',
           'HTTP_OIDC_email'                   => 'ben.dover@majl.ru',
           'HTTP_OIDC_edu_person_entitlements' => 'urn:mace:egi.eu:aai.egi.eu:member@fedcloud.egi.eu',
-          'HTTP_OIDC_access_token_expires'    => '1000691200',
+          'HTTP_OIDC_access_token_expires'    => '1000028800',
           'HTTP_OIDC_name'                    => 'Ben Dover',
           'HTTP_OIDC_iss'                     => 'gogol.com',
           'HTTP_OIDC_acr'                     => 'goglo.com'

--- a/spec/controllers/v3/auth/federation_controller_spec.rb
+++ b/spec/controllers/v3/auth/federation_controller_spec.rb
@@ -13,6 +13,10 @@ describe V3::Auth::FederationController do
     let(:method) { :get }
   end
 
+  before do
+    allow(Time).to receive(:now).and_return(Time.zone.at(1_000_000_000))
+  end
+
   describe 'GET #voms', type: :request do
     let(:headers) { JSON_HEADERS.merge(voms_env) }
 
@@ -70,7 +74,7 @@ describe V3::Auth::FederationController do
         authentication:  { type: 'federation', method: 'oidc' },
         name:            'Ben Dover',
         identity:        '1',
-        expiration:      '123456789',
+        expiration:      '1000691200',
         issuer:          'gogol.com',
         acr:             'goglo.com'
       }
@@ -84,7 +88,7 @@ describe V3::Auth::FederationController do
           'OIDC_sub'                     => '1',
           'OIDC_email'                   => 'ben.dover@majl.ru',
           'OIDC_edu_person_entitlements' => 'urn:mace:egi.eu:aai.egi.eu:member@fedcloud.egi.eu',
-          'OIDC_access_token_expires'    => '123456789',
+          'OIDC_access_token_expires'    => '1000691200',
           'OIDC_name'                    => 'Ben Dover',
           'OIDC_iss'                     => 'gogol.com',
           'OIDC_acr'                     => 'goglo.com'
@@ -132,7 +136,7 @@ describe V3::Auth::FederationController do
           'HTTP_OIDC_sub'                     => '1',
           'HTTP_OIDC_email'                   => 'ben.dover@majl.ru',
           'HTTP_OIDC_edu_person_entitlements' => 'urn:mace:egi.eu:aai.egi.eu:member@fedcloud.egi.eu',
-          'HTTP_OIDC_access_token_expires'    => '123456789',
+          'HTTP_OIDC_access_token_expires'    => '1000691200',
           'HTTP_OIDC_name'                    => 'Ben Dover',
           'HTTP_OIDC_iss'                     => 'gogol.com',
           'HTTP_OIDC_acr'                     => 'goglo.com'

--- a/spec/controllers/v3/auth/federation_controller_spec.rb
+++ b/spec/controllers/v3/auth/federation_controller_spec.rb
@@ -74,7 +74,7 @@ describe V3::Auth::FederationController do
         authentication:  { type: 'federation', method: 'oidc' },
         name:            'Ben Dover',
         identity:        '1',
-        expiration:      '1000028800',
+        expiration:      1_000_028_800,
         issuer:          'gogol.com',
         acr:             'goglo.com'
       }
@@ -88,7 +88,6 @@ describe V3::Auth::FederationController do
           'OIDC_sub'                     => '1',
           'OIDC_email'                   => 'ben.dover@majl.ru',
           'OIDC_edu_person_entitlements' => 'urn:mace:egi.eu:aai.egi.eu:member@fedcloud.egi.eu',
-          'OIDC_access_token_expires'    => '1000028800',
           'OIDC_name'                    => 'Ben Dover',
           'OIDC_iss'                     => 'gogol.com',
           'OIDC_acr'                     => 'goglo.com'
@@ -136,7 +135,6 @@ describe V3::Auth::FederationController do
           'HTTP_OIDC_sub'                     => '1',
           'HTTP_OIDC_email'                   => 'ben.dover@majl.ru',
           'HTTP_OIDC_edu_person_entitlements' => 'urn:mace:egi.eu:aai.egi.eu:member@fedcloud.egi.eu',
-          'HTTP_OIDC_access_token_expires'    => '1000028800',
           'HTTP_OIDC_name'                    => 'Ben Dover',
           'HTTP_OIDC_iss'                     => 'gogol.com',
           'HTTP_OIDC_acr'                     => 'goglo.com'

--- a/spec/models/auth/voms_spec.rb
+++ b/spec/models/auth/voms_spec.rb
@@ -136,7 +136,7 @@ describe Auth::Voms, type: :model do
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
           identity: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
-          expiration: '1000691200',
+          expiration: '1000028800',
           acr: nil,
           issuer: nil }
       end
@@ -166,7 +166,7 @@ describe Auth::Voms, type: :model do
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
           identity: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
-          expiration: '1000691200',
+          expiration: '1000028800',
           acr: nil,
           issuer: nil }
       end

--- a/spec/models/auth/voms_spec.rb
+++ b/spec/models/auth/voms_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 describe Auth::Voms, type: :model do
+  before do
+    allow(Time).to receive(:now).and_return(Time.zone.at(1_000_000_000))
+  end
+
   describe '#parse_hash_dn!' do
     context 'with correct hash' do
       let(:dn_hash) do
@@ -116,32 +120,6 @@ describe Auth::Voms, type: :model do
     end
   end
 
-  describe '#parse_hash_exp!' do
-    context 'with correct hash' do
-      let(:exp_hash) do
-        { 'GRST_CRED_0' => %(X509USER 1492646400 1526731200 1 /DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535),
-          'GRST_CRED_1' => %(GSIPROXY 1500381287 1500424487 1 /DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535/CN=99672074),
-          'GRST_CRED_2' => %(VOMS 1500381287 1500424487 0 /fedcloud.egi.eu/Role=NULL/Capability=NULL) }
-      end
-
-      it 'will parse correct time' do
-        expect(Auth::Voms.send(:parse_hash_exp!, exp_hash)).to eq('1500424487')
-      end
-    end
-
-    context 'with incorrect hash with no VOMS variable' do
-      let(:exp_hash) do
-        { 'GRST_CRED_0' => %(X509USER 1492646400 1526731200 1 /DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535),
-          'GRST_CRED_1' => %(GSIPROXY 1500381287 1500424487 1 /DC=org/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535/CN=99672074) }
-      end
-
-      it 'will raise error' do
-        expect { Auth::Voms.send(:parse_hash_exp!, exp_hash) }.to \
-          raise_error(Errors::AuthenticationError)
-      end
-    end
-  end
-
   describe '#unified_credentials' do
     context 'with correct hash with NULL' do
       let(:env_hash) do
@@ -158,7 +136,7 @@ describe Auth::Voms, type: :model do
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
           identity: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
-          expiration: '1500424487',
+          expiration: '1000691200',
           acr: nil,
           issuer: nil }
       end
@@ -188,7 +166,7 @@ describe Auth::Voms, type: :model do
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
           identity: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
-          expiration: '1500424487',
+          expiration: '1000691200',
           acr: nil,
           issuer: nil }
       end

--- a/spec/models/auth/voms_spec.rb
+++ b/spec/models/auth/voms_spec.rb
@@ -136,7 +136,7 @@ describe Auth::Voms, type: :model do
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
           identity: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
-          expiration: '1000028800',
+          expiration: 1_000_028_800,
           acr: nil,
           issuer: nil }
       end
@@ -166,7 +166,7 @@ describe Auth::Voms, type: :model do
           authentication: { type: 'federation', method: 'voms' },
           name: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
           identity: '/DC=org/DC=terena/DC=tcs/C=CZ/O=CESNET/CN=Michal Kimle 1535',
-          expiration: '1000028800',
+          expiration: 1_000_028_800,
           acr: nil,
           issuer: nil }
       end


### PR DESCRIPTION
Tokens are now valid for fixed expiration window that can be set in
keystorm.yml config file. I also had to change specs a bit so that they
use same time all the time (1_000_000_000 seconds from epoch). Also set
default expiration window to 8 days (691_200 seconds).
fixes #52