### PR TITLE
Remove misleading attribute from OpenNebula user autocreate

### DIFF
--- a/app/models/clouds/opennebula.rb
+++ b/app/models/clouds/opennebula.rb
@@ -57,6 +57,7 @@ module Clouds
       Rails.logger.debug { "Generating OpenNebula user template from credentials #{hash.inspect}" }
       hash[:authentication] = hash[:authentication][:method]
       hash.delete :groups
+      hash.delete :expiration
 
       template = hash.map { |key, value| "\"#{key.upcase}\" = \"#{value}\"" }.join("\n")
       Rails.logger.debug { "Template: #{template.inspect}" }


### PR DESCRIPTION
It isn't covered by tests but I'm fairly certain this is all that needs to be done.
Closes #76 