### PR TITLE
Fix software version used while building Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,10 @@ FROM ruby:2.4-stretch
 ARG branch=master
 ARG version
 
-ENV name="keystorm"
-ENV appDir="/opt/${name}" \
+ENV name="keystorm" \
+    project="the-rocci-project" \
+    installDir="/opt"
+ENV appDir="${installDir}/${name}-${version}" \
     logDir="/var/log/${name}" \
     TERM="xterm"
 
@@ -16,7 +18,7 @@ LABEL application=${name} \
 
 SHELL ["/bin/bash", "-c"]
 
-RUN git clone https://github.com/the-rocci-project/keystorm.git ${appDir}
+RUN curl -SsL https://github.com/${project}/${name}/archive/v${version}.tar.gz | tar -xzC ${installDir}
 
 RUN useradd --system --shell /bin/false --home ${appDir} ${name} && \
     usermod -L ${name} && \


### PR DESCRIPTION
I realized that since the Docker image is not build upon a gem I'm not using the correct version of the software while preparing the image. This pull request is a fix for that.

As before, I have the same one ready for the rOCCI-server. 