### PR TITLE
Remove yard development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ group :development, :test do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'vcr', '~> 3.0'
   gem 'webmock', '~> 3.0'
-  gem 'yard'
 end
 
 # Include external bundles

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,6 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
     xmlrpc (0.3.0)
-    yard (0.9.9)
 
 PLATFORMS
   ruby
@@ -247,7 +246,6 @@ DEPENDENCIES
   vcr (~> 3.0)
   webmock (~> 3.0)
   xmlrpc (~> 0.3)
-  yard
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/lib/tasks/yard.rake
+++ b/lib/tasks/yard.rake
@@ -1,1 +1,0 @@
-YARD::Rake::YardocTask.new unless Rails.env.production?


### PR DESCRIPTION
There is a known vulnerability in yard gem 0.9.10 and older ([CVE](https://nvd.nist.gov/vuln/detail/CVE-2017-17042)). Instead of updating I removed the dependency. Keystorm doesn't have any YARD documentation and I highly doubt that it ever will. I'll add it back if once needed.